### PR TITLE
MFE figures

### DIFF
--- a/RunCostingForCustomer.py
+++ b/RunCostingForCustomer.py
@@ -128,6 +128,11 @@ with open(f"{customer_folder}/output/{report_content.document_template.template_
 for hydrated_template in report_content.hydrated_templates:
     with open(f"{customer_folder}/output/{hydrated_template.template_provider.template_file}", "w") as file:
         file.write(hydrated_template.contents)
+for tex_path, figure_bytes in report_content.figures.items():
+    output_file = f'{customer_folder}/output/{tex_path}'
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
+    with open(output_file, "wb") as file:
+        file.write(figure_bytes)
 
 print(f"Costing run completed for {customer_name}. Data saved to {customer_folder}")
 

--- a/customers/CATF/ife/data.json
+++ b/customers/CATF/ife/data.json
@@ -3,6 +3,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "p_alpha": null,
         "p_neutron": null,
         "p_cool": null,
@@ -24,6 +25,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C110000": null,
         "C120000": null,
         "C130000": null,
@@ -38,6 +40,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C210100": null,
         "C210200": null,
         "C210300": null,
@@ -62,6 +65,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C220100": null,
         "C220000": null
     },
@@ -69,6 +73,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "axis_ir": null,
         "plasma_ir": null,
         "vacuum_ir": null,
@@ -119,6 +124,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C22010201": null,
         "C22010202": null,
         "C22010203": null,
@@ -130,6 +136,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "magnet_properties": [],
         "no_pf_coils": null,
         "no_pf_pairs": null,
@@ -146,6 +153,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C22010401": null,
         "C22010402": null,
         "C220104": null
@@ -154,6 +162,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C22010501": null,
         "C22010502": null,
         "C220105": null
@@ -162,6 +171,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C22010601": null,
         "C22010602": null,
         "C22010603": null,
@@ -233,6 +243,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C22010701": null,
         "C22010702": null,
         "C220107": null
@@ -241,6 +252,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C220108": null,
         "divertor_maj_rad": null,
         "divertor_min_rad": null,
@@ -256,6 +268,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C220109": null,
         "costs": null,
         "scaled_costs": null
@@ -264,18 +277,21 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C220111": null
     },
     "cas220119": {
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C220119": null
     },
     "cas2202": {
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C220201": null,
         "C220202": null,
         "C220203": null,
@@ -285,18 +301,21 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C220300": null
     },
     "cas2204": {
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C220400": null
     },
     "cas2205": {
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C2205010ITER": null,
         "C2205020ITER": null,
         "C2205030ITER": null,
@@ -316,42 +335,49 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C220600": null
     },
     "cas2207": {
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C220700": null
     },
     "cas23": {
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C230000": null
     },
     "cas24": {
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C240000": null
     },
     "cas25": {
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C250000": null
     },
     "cas26": {
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C260000": null
     },
     "cas27": {
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C271000": null,
         "C274000": null,
         "C275000": null,
@@ -361,24 +387,28 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C280000": null
     },
     "cas29": {
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C290000": null
     },
     "cas20": {
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C200000": null
     },
     "cas30": {
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C310000LSA": null,
         "C310000": null,
         "C320000LSA": null,
@@ -391,6 +421,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C400000LSA": null,
         "C400000": null,
         "C410000": null,
@@ -402,6 +433,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C510000": null,
         "C520000": null,
         "C530000": null,
@@ -415,6 +447,7 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C610000": null,
         "C630000LSA": null,
         "C630000": null,
@@ -424,18 +457,21 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C700000": null
     },
     "cas80": {
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C800000": null
     },
     "cas90": {
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C990000": null,
         "C900000": null
     },
@@ -443,12 +479,14 @@
         "replacements": {},
         "template_file": null,
         "tex_path": null,
+        "figures": {},
         "C1000000": null,
         "C2000000": null
     },
     "cost_table": {
         "replacements": {},
         "template_file": null,
-        "tex_path": null
+        "tex_path": null,
+        "figures": {}
     }
 }

--- a/customers/CATF/mfe/data.json
+++ b/customers/CATF/mfe/data.json
@@ -33,6 +33,7 @@
         },
         "template_file": "powerTableMFEDT.tex",
         "tex_path": "Modified/powerTableMFEDT.tex",
+        "figures": {},
         "p_alpha": 520.5915813424347,
         "p_neutron": 2079.4084186575656,
         "p_cool": 13.7,
@@ -65,6 +66,7 @@
         },
         "template_file": "CAS100000.tex",
         "tex_path": "Modified/CAS100000.tex",
+        "figures": {},
         "C110000": 17.621203250174933,
         "C120000": 10.0,
         "C130000": 200.0,
@@ -99,6 +101,7 @@
         },
         "template_file": "CAS210000.tex",
         "tex_path": "Modified/CAS210000.tex",
+        "figures": {},
         "C210100": 207.26097448591588,
         "C210200": 144.46399266406377,
         "C210300": 83.5230792704437,
@@ -173,6 +176,7 @@
         },
         "template_file": "CAS220000.tex",
         "tex_path": "Modified/CAS220000.tex",
+        "figures": {},
         "C220100": 38151.41086054635,
         "C220000": 38605.916403179945
     },
@@ -245,6 +249,9 @@
         },
         "template_file": "CAS220101_MFE_DT.tex",
         "tex_path": "Modified/CAS220101_MFE_DT.tex",
+        "figures": {
+            "Figures/radial_build.pdf": ""
+        },
         "axis_ir": 3,
         "plasma_ir": 3,
         "vacuum_ir": 4.1,
@@ -305,6 +312,7 @@
         },
         "template_file": "CAS220102.tex",
         "tex_path": "Modified/CAS220102.tex",
+        "figures": {},
         "C22010201": 168.9,
         "C22010202": 2.835339952344955,
         "C22010203": 0.6069557006735483,
@@ -358,6 +366,7 @@
         },
         "template_file": "CAS220103_MFE_DT_tokamak.tex",
         "tex_path": "Modified/CAS220103_MFE_DT_tokamak.tex",
+        "figures": {},
         "magnet_properties": [
             {
                 "magnet": {
@@ -902,6 +911,7 @@
         },
         "template_file": "CAS220104_MFE_DT.tex",
         "tex_path": "Modified/CAS220104_MFE_DT.tex",
+        "figures": {},
         "C22010401": 176.605,
         "C22010402": 103.734583325,
         "C220104": 280.339583325
@@ -916,6 +926,7 @@
         },
         "template_file": "CAS220105.tex",
         "tex_path": "Modified/CAS220105.tex",
+        "figures": {},
         "C22010501": 205.73575683321957,
         "C22010502": 296.47151366643914,
         "C220105": 502.2072704996587
@@ -933,6 +944,7 @@
         },
         "template_file": "CAS220106_MFE.tex",
         "tex_path": "Modified/CAS220106_MFE.tex",
+        "figures": {},
         "C22010601": 1.7780179023697384,
         "C22010602": 767.7962407072313,
         "C22010603": 12.48,
@@ -1009,6 +1021,7 @@
         },
         "template_file": "CAS220107_MFE.tex",
         "tex_path": "Modified/CAS220107_MFE.tex",
+        "figures": {},
         "C22010701": 2.0,
         "C22010702": 1401.9200000000003,
         "C220107": 1403.9200000000003
@@ -1025,6 +1038,7 @@
         },
         "template_file": "CAS220108_MFE.tex",
         "tex_path": "Modified/CAS220108_MFE.tex",
+        "figures": {},
         "C220108": 132.7129374034226,
         "divertor_maj_rad": 3.8,
         "divertor_min_rad": 1.1999999999999993,
@@ -1062,6 +1076,7 @@
         },
         "template_file": "CAS220109.tex",
         "tex_path": "Modified/CAS220109.tex",
+        "figures": {},
         "C220109": 0.0,
         "costs": {
             "expandertank": 16.0,
@@ -1099,6 +1114,7 @@
         },
         "template_file": "CAS220111.tex",
         "tex_path": "Modified/CAS220111.tex",
+        "figures": {},
         "C220111": 89.75999999999998
     },
     "cas220119": {
@@ -1107,6 +1123,7 @@
         },
         "template_file": "CAS220119.tex",
         "tex_path": "Modified/CAS220119.tex",
+        "figures": {},
         "C220119": 0.0
     },
     "cas2202": {
@@ -1120,6 +1137,7 @@
         },
         "template_file": "CAS220200_DT.tex",
         "tex_path": "Modified/CAS220200_DT.tex",
+        "figures": {},
         "C220201": 218.68123001636081,
         "C220202": 32.995337097914735,
         "C220203": 0.0,
@@ -1131,6 +1149,7 @@
         },
         "template_file": "CAS220300.tex",
         "tex_path": "Modified/CAS220300.tex",
+        "figures": {},
         "C220300": 5.333866782452789
     },
     "cas2204": {
@@ -1139,6 +1158,7 @@
         },
         "template_file": "CAS220400.tex",
         "tex_path": "Modified/CAS220400.tex",
+        "figures": {},
         "C220400": 9.503980812370424
     },
     "cas2205": {
@@ -1162,6 +1182,7 @@
         },
         "template_file": "CAS220500_DT.tex",
         "tex_path": "Modified/CAS220500_DT.tex",
+        "figures": {},
         "C2205010ITER": 29.26495,
         "C2205020ITER": 10.01,
         "C2205030ITER": 32.190729999999995,
@@ -1183,6 +1204,7 @@
         },
         "template_file": "CAS220600.tex",
         "tex_path": "Modified/CAS220600.tex",
+        "figures": {},
         "C220600": 14.337075633811484
     },
     "cas2207": {
@@ -1191,6 +1213,7 @@
         },
         "template_file": "CAS220700.tex",
         "tex_path": "Modified/CAS220700.tex",
+        "figures": {},
         "C220700": 85.0
     },
     "cas23": {
@@ -1199,6 +1222,7 @@
         },
         "template_file": "CAS230000.tex",
         "tex_path": "Modified/CAS230000.tex",
+        "figures": {},
         "C230000": 389.5423613752083
     },
     "cas24": {
@@ -1207,6 +1231,7 @@
         },
         "template_file": "CAS240000.tex",
         "tex_path": "Modified/CAS240000.tex",
+        "figures": {},
         "C240000": 96.05154116101025
     },
     "cas25": {
@@ -1215,6 +1240,7 @@
         },
         "template_file": "CAS250000.tex",
         "tex_path": "Modified/CAS250000.tex",
+        "figures": {},
         "C250000": 67.59182526145166
     },
     "cas26": {
@@ -1223,6 +1249,7 @@
         },
         "template_file": "CAS260000.tex",
         "tex_path": "Modified/CAS260000.tex",
+        "figures": {},
         "C260000": 190.3243500782981
     },
     "cas27": {
@@ -1231,6 +1258,7 @@
         },
         "template_file": "CAS270000.tex",
         "tex_path": "Modified/CAS270000.tex",
+        "figures": {},
         "C271000": 106.5,
         "C274000": 0.7011,
         "C275000": 0.3591,
@@ -1242,6 +1270,7 @@
         },
         "template_file": "CAS280000.tex",
         "tex_path": "Modified/CAS280000.tex",
+        "figures": {},
         "C280000": 5.0
     },
     "cas29": {
@@ -1250,6 +1279,7 @@
         },
         "template_file": "CAS290000.tex",
         "tex_path": "Modified/CAS290000.tex",
+        "figures": {},
         "C290000": 0.0
     },
     "cas20": {
@@ -1258,6 +1288,7 @@
         },
         "template_file": "CAS200000.tex",
         "tex_path": "Modified/CAS200000.tex",
+        "figures": {},
         "C200000": 40828.722217902185
     },
     "cas30": {
@@ -1272,6 +1303,7 @@
         },
         "template_file": "CAS300000.tex",
         "tex_path": "Modified/CAS300000.tex",
+        "figures": {},
         "C310000LSA": 2449.723333074131,
         "C310000": 53.34314111324291,
         "C320000LSA": 4899.446666148262,
@@ -1288,6 +1320,7 @@
         },
         "template_file": "CAS400000.tex",
         "tex_path": "Modified/CAS400000.tex",
+        "figures": {},
         "C400000LSA": 4899.446666148262,
         "C400000": 4899.446666148262,
         "C410000": 0.0,
@@ -1308,6 +1341,7 @@
         },
         "template_file": "CAS500000.tex",
         "tex_path": "Modified/CAS500000.tex",
+        "figures": {},
         "C510000": 8.0,
         "C520000": 85.60702778759685,
         "C530000": 100.0,
@@ -1326,6 +1360,7 @@
         },
         "template_file": "CAS600000.tex",
         "tex_path": "Modified/CAS600000.tex",
+        "figures": {},
         "C610000": 299.0,
         "C630000LSA": 11170.738398818037,
         "C630000": 782.5099435525201,
@@ -1337,6 +1372,7 @@
         },
         "template_file": "CAS700000.tex",
         "tex_path": "Modified/CAS700000.tex",
+        "figures": {},
         "C700000": 79.04140843964848
     },
     "cas80": {
@@ -1347,6 +1383,7 @@
         },
         "template_file": "CAS800000_DT.tex",
         "tex_path": "Modified/CAS800000_DT.tex",
+        "figures": {},
         "C800000": 0.1798689072895579
     },
     "cas90": {
@@ -1355,6 +1392,7 @@
         },
         "template_file": "CAS900000.tex",
         "tex_path": "Modified/CAS900000.tex",
+        "figures": {},
         "C990000": 48010.22364053452,
         "C900000": 4320.920127648106
     },
@@ -1372,6 +1410,7 @@
         },
         "template_file": "LCOE.tex",
         "tex_path": "Modified/LCOE.tex",
+        "figures": {},
         "C1000000": 457.1984620577469,
         "C2000000": 45.71984620577469
     },
@@ -1515,6 +1554,7 @@
             "M.28pp": "-"
         },
         "template_file": "CASstructure.tex",
-        "tex_path": "Modified/CASstructure.tex"
+        "tex_path": "Modified/CASstructure.tex",
+        "figures": {}
     }
 }

--- a/customers/CATF/mfe/inputs.json
+++ b/customers/CATF/mfe/inputs.json
@@ -16,7 +16,8 @@
         "plant_availability": 0.85,
         "noak": true,
         "yearly_inflation": 0.0245,
-        "time_to_replace": 10
+        "time_to_replace": 10,
+        "implosion_frequency": null
     },
     "power_table": {
         "f_sub": 0.03,

--- a/pyfecons/costing/mfe/CAS22.py
+++ b/pyfecons/costing/mfe/CAS22.py
@@ -1,4 +1,5 @@
 import math
+from io import BytesIO
 from typing import Optional, Tuple
 
 import matplotlib.pyplot as plt
@@ -7,7 +8,7 @@ import numpy as np
 from pyfecons import BlanketFirstWall, BlanketType, MagnetMaterialType
 from pyfecons.costing.calculations.YuhuHtsCiccExtrapolation import YuhuHtsCiccExtrapolation
 from pyfecons.helpers import safe_round
-from pyfecons.inputs import Inputs, Coils, Magnet
+from pyfecons.inputs import Inputs, Coils, Magnet, RadialBuild
 from pyfecons.data import Data, MagnetProperties, VesselCosts, VesselCost, TemplateProvider
 from pyfecons.units import M_USD, Kilometers, Turns, Amperes, Meters2, MA, Meters3, Meters, Kilograms, MW, Count, USD
 
@@ -160,7 +161,7 @@ def compute_220101_reactor_equipment(inputs: Inputs, data: Data, figures: dict) 
     # Total cost of blanket and first wall
     OUT.C220101 = M_USD(OUT.C22010101 + OUT.C22010102)
 
-    # TODO - PLOTTING RADIAL BUILD
+    OUT.figures['Figures/radial_build.pdf'] = plot_radial_build(IN)
 
     OUT.template_file = CAS_220101_MFE_DT_TEX
     OUT.tex_path = 'Modified/' + OUT.template_file
@@ -287,13 +288,13 @@ def compute_220102_shield(inputs: Inputs, data: Data) -> TemplateProvider:
     return OUT
 
 
-def plot_radial_build(IN, figures):
+def plot_radial_build(radial_build: RadialBuild) -> bytes:
     """
     PLOTTING RADIAL BUILD
     """
+    IN = radial_build
 
-    ## The names of the sections
-
+    # The names of the sections
     # Updated order of the sections
     sections = ['Plasma', 'Vacuum', 'First Wall', 'Blanket', 'Reflector', 'HT Shield', 'Structure', 'Gap', 'Vessel',
                 'LT Shield', 'Coil', 'Gap', 'Bioshield']
@@ -324,13 +325,11 @@ def plot_radial_build(IN, figures):
     # Show grid for the x-axis
     ax.xaxis.grid(True)
 
-    # Show the plot
-    plt.tight_layout()  # TODO comment or delete
-    plt.show()  # TODO comment or delete
-    figures["radial_build.pdf"] = fig
-
-    # Export as pdf
-    # fig.savefig(os.path.join(figures_directory, 'radial_build.pdf'), bbox_inches='tight')
+    # save figure
+    figure_data = BytesIO()
+    fig.savefig(figure_data, format='pdf', bbox_inches='tight')
+    figure_data.seek(0)
+    return figure_data.getvalue()
 
 
 # Steel thermal conductivity function
@@ -1131,8 +1130,8 @@ def compute_2200_reactor_plant_equipment_total(inputs: Inputs, data: Data) -> Te
     # Cost category 22.1 total
     # TODO - I added C220119 since it's zero now, is this OK?
     OUT.C220100 = M_USD(data.cas220101.C220101 + data.cas220102.C220102 + data.cas220103.C220103
-                               + data.cas220104.C220104 + data.cas220105.C220105 + data.cas220106.C220106
-                               + data.cas220107.C220107 + data.cas220111.C220111 + data.cas220119.C220119)
+                        + data.cas220104.C220104 + data.cas220105.C220105 + data.cas220106.C220106
+                        + data.cas220107.C220107 + data.cas220111.C220111 + data.cas220119.C220119)
 
     # Cost category 22.2 total
     OUT.C220000 = M_USD(OUT.C220100 + data.cas2202.C220200 + data.cas2203.C220300 + data.cas2204.C220400

--- a/pyfecons/costing/mfe/mfe.py
+++ b/pyfecons/costing/mfe/mfe.py
@@ -1,5 +1,5 @@
 from pyfecons.helpers import load_remote_included_files, load_github_images
-from pyfecons.templates import read_template, hydrate_templates
+from pyfecons.templates import read_template, hydrate_templates, combine_figures
 from pyfecons.inputs import Inputs
 from pyfecons.data import Data, TemplateProvider
 from pyfecons.costing.mfe.PowerBalance import GenerateData as PowerBalanceData
@@ -94,6 +94,7 @@ def load_document_template() -> HydratedTemplate:
 def CreateReportContent(costing_data: CostingData) -> ReportContent:
     document_template = load_document_template()
     hydrated_templates = hydrate_templates(TEMPLATES_PATH, costing_data.template_providers)
+    figures = combine_figures(costing_data.template_providers)
     included_files = load_remote_included_files(CACHE, BASE_URL, INCLUDED_FILES)
     included_files = included_files | load_github_images(CACHE, INCLUDED_IMAGES)
-    return ReportContent(document_template, hydrated_templates, included_files)
+    return ReportContent(document_template, hydrated_templates, included_files, figures)

--- a/pyfecons/costing/mfe/templates/CAS220101_MFE_DT.tex
+++ b/pyfecons/costing/mfe/templates/CAS220101_MFE_DT.tex
@@ -42,13 +42,12 @@ The blanket under consideration has a firstW first wall with a primary coolant c
     \label{tab:volumes}
 \end{table}
 
-% TODO - implement this graphic
-%\begin{figure}
-%    \centering
-%    \includegraphics[width=0.9\linewidth]{Figures/radial_build.pdf}
-%    \caption{Radial build according to Table \ref{tab:volumes}.}
-%    \label{fig:radial}
-%\end{figure}
+\begin{figure}
+    \centering
+    \includegraphics[width=0.9\linewidth]{Figures/radial_build.pdf}
+    \caption{Radial build according to Table \ref{tab:volumes}.}
+    \label{fig:radial}
+\end{figure}
 
 
 

--- a/pyfecons/data.py
+++ b/pyfecons/data.py
@@ -8,6 +8,8 @@ class TemplateProvider:
     replacements: dict[str, str] = field(default_factory=dict)
     template_file: str = None
     tex_path: str = None
+    # latex path -> image bytes
+    figures: dict[str, bytes] = field(default_factory=dict)
 
 
 @dataclass

--- a/pyfecons/pyfecons.py
+++ b/pyfecons/pyfecons.py
@@ -61,6 +61,13 @@ def RenderFinalReport(report_content: ReportContent, hide_output: bool = False) 
             with open(output_path, 'w') as template_file:
                 template_file.write(hydrated_template.contents)
 
+        # Write figures to tex compile directory
+        for tex_path, figure_bytes in report_content.figures.items():
+            output_path = os.path.join(temp_dir, tex_path)
+            os.makedirs(os.path.dirname(output_path), exist_ok=True)
+            with open(output_path, 'wb') as template_file:
+                template_file.write(figure_bytes)
+
         # Copy included files to tex compile directory
         for tex_path, local_path in report_content.included_files.items():
             full_dest_path = os.path.join(temp_dir, tex_path)

--- a/pyfecons/report.py
+++ b/pyfecons/report.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from pyfecons.data import Data, TemplateProvider
 
@@ -24,9 +24,11 @@ class ReportContent:
     # Top level document file as base of tex compilation
     document_template: HydratedTemplate = None
     # Hydrated templates to be included in tex compilation
-    hydrated_templates: list[HydratedTemplate] = None
+    hydrated_templates: list[HydratedTemplate] = field(default_factory=list)
     # tex file path -> local file path of files to include in tex compilation
-    included_files: dict[str, str] = None
+    included_files: dict[str, str] = field(default_factory=dict)
+    # latex path -> image bytes
+    figures: dict[str, bytes] = field(default_factory=dict)
 
 
 @dataclass

--- a/pyfecons/serializable.py
+++ b/pyfecons/serializable.py
@@ -12,6 +12,8 @@ class PyfeconsEncoder(json.JSONEncoder):
                 return {"value": obj.value, "display_name": obj.display_name}
             else:
                 return obj.value  # Return just the value if there's no 'display_name'
+        elif isinstance(obj, bytes):
+            return ''
         # Let the base class default method raise the TypeError for other types
         return json.JSONEncoder.default(self, obj)
 

--- a/pyfecons/templates.py
+++ b/pyfecons/templates.py
@@ -21,3 +21,10 @@ def hydrate_templates(templates_path: str, template_providers: list[TemplateProv
         contents = replace_values(template_content, provider.replacements)
         hydrated_templates.append(HydratedTemplate(provider, contents))
     return hydrated_templates
+
+
+def combine_figures(template_providers: list[TemplateProvider]) -> dict[str, bytes]:
+    all_figures = {}
+    for provider in template_providers:
+        all_figures.update(provider.figures)
+    return all_figures

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='pyfecons',
-    version='0.0.18',
+    version='0.0.19',
     author='nTtau Digital LTD',
     author_email='info@nttaudigital.com',
     description='Library for nTtau PyFECONS costing calculations.',


### PR DESCRIPTION
https://trello.com/c/j4POTYRV/26-implement-mfe-figures

Changes
* Implement MFE figures.
* Add figures to template provider and report content.
* Save figures to latex compilation folder and customer output.
* Ignore binary data in pyfecons serializer.