### PR TITLE
Custom templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ python3 RunCostingForCustomer.py mfe CATF
 This will use inputs from `customers/CATF/mfe/DefineInputs.py` file, output assets to `customers/CATF/mfe/outputs/`,
 and create a copy of the inputs `input.json` and outputs `data.json`.
 
+### Customer Custom Templates
+
+You can override the library templates in `pyfecons/costing/REACTOR_TYPE/templates` folder by adding a template of the
+exact same file name to the `customers/CUSTOMER_NAME/REACTOR_TYPE/templates` directory. The costing code will use
+files in the `customers/` directory before the library with the same substitutions.
+
+### Customer Custom Included Files
+
+You can override the library included files in `pyfecons/costing/REACTOR_TYPE/included_files` folder by adding a
+template of the exact same file name to the `customers/CUSTOMER_NAME/REACTOR_TYPE/included_files` directory.
+The costing code will use  files in the `customers/` directory before the library with the same substitutions. NB you
+must have the file in the same directory structure relative to `included_files/`.
+I.e. `customers/CATF/ife/included_files/StandardFigures/WSLTD_logo.png`.
 
 ## Importing PyFECONs into your project
 
@@ -87,8 +100,6 @@ The library should work out of the box on linux with a python virtual environmen
 
 Because of OS specific dependencies, in order to use PyFECONs on Mac M1 (and Windows?) you'll need to use conda dependency management in your project. See the steps below in the README for setting this up in your environment.
 
-TODO verify dependencies on Windows. For now consider using conda.
-
 ### Installing LaTeX
 
 LaTeX is an external dependency to the library since installation varies widely by OS.
@@ -111,8 +122,9 @@ TODO
 
 ### Python Virtual Environment
 
-Preferred dependency management should work on linux machines.
+Preferred dependency management for Linux and Windows.
 
+Linux Commands
 ```bash
 # remove existing environment (on clean up)
 rm -rf venv
@@ -122,6 +134,21 @@ python3 -m venv venv
 
 # activate virtual environment (on new terminal)
 source venv/bin/activate
+
+# install dependencies (on new environment or after changes)
+pip install -r requirements.txt
+```
+
+Windows Commands
+```bash
+# remove existing environment (on clean up)
+rm -rf venv
+
+# create virtual environment (on new environment)
+python3 -m venv venv
+
+# activate virtual environment (on new shell)
+venv\Scripts\activate
 
 # install dependencies (on new environment or after changes)
 pip install -r requirements.txt

--- a/RunCostingForCustomer.py
+++ b/RunCostingForCustomer.py
@@ -3,6 +3,7 @@ import os
 import json
 import shutil
 
+from pyfecons.helpers import load_customer_overrides
 from pyfecons.serializable import PyfeconsEncoder
 
 #################
@@ -101,8 +102,11 @@ with open(f"{customer_folder}/data.json", "w", encoding='utf-8') as file:
 # HYDRATE THE TEMPLATES #
 #########################
 
+overrides = load_customer_overrides(customer_folder)
+
 # fill in the templates and copy them to the customer's folder
-report_content = CreateReportContent(inputs, costing_data)
+report_content = CreateReportContent(inputs, costing_data, overrides)
+
 
 # delete the existing contents of the output folder
 # Loop through all the items in the directory

--- a/customers/.gitignore
+++ b/customers/.gitignore
@@ -1,1 +1,3 @@
 **/output/**
+**/templates/**
+**/included_files/**

--- a/pyfecons/costing/calculations/cas22/cas220101_reactor_equipment.py
+++ b/pyfecons/costing/calculations/cas22/cas220101_reactor_equipment.py
@@ -133,7 +133,6 @@ def plot_radial_build(reactor_type: ReactorType, radial_build: RadialBuild) -> b
 
     # Show the plot
     plt.tight_layout()
-    # plt.show()
 
     # save figure
     figure_data = BytesIO()

--- a/pyfecons/costing/ife/cas22/CAS220107.py
+++ b/pyfecons/costing/ife/cas22/CAS220107.py
@@ -90,7 +90,6 @@ def generate_cap_derate_figure(IN: PowerSupplies, implosion_frequency: HZ) -> by
 
     # Show updated plots
     plt.tight_layout()
-    plt.show()
 
     # Plotting the stacked bar graph
     # Adjust the figsize to get the desired aspect ratio

--- a/pyfecons/costing/ife/ife.py
+++ b/pyfecons/costing/ife/ife.py
@@ -1,9 +1,11 @@
-from pyfecons.data import Data, TemplateProvider
+from typing import Optional
+
+from pyfecons.data import Data
 from pyfecons.enums import ReactorType
 from pyfecons.helpers import get_local_included_files_map
 from pyfecons.inputs import Inputs
-from pyfecons.report import CostingData, ReportContent, HydratedTemplate
-from pyfecons.templates import read_template, hydrate_templates, combine_figures
+from pyfecons.report import CostingData, ReportContent, ReportOverrides
+from pyfecons.templates import hydrate_templates, combine_figures, load_document_template
 from pyfecons.costing.ife.PowerBalance import power_balance
 from pyfecons.costing.ife.CAS10 import cas_10
 from pyfecons.costing.ife.CAS21 import cas_21
@@ -114,16 +116,10 @@ def GenerateCostingData(inputs: Inputs) -> CostingData:
     return CostingData(data, template_providers)
 
 
-def CreateReportContent(costing_data: CostingData) -> ReportContent:
-    document_template = load_document_template()
-    hydrated_templates = hydrate_templates(TEMPLATES_PATH, costing_data.template_providers)
+def CreateReportContent(costing_data: CostingData,
+                        overrides: Optional[ReportOverrides] = None) -> ReportContent:
+    document_template = load_document_template(TEMPLATES_PATH, DOCUMENT_TEMPLATE, overrides)
+    hydrated_templates = hydrate_templates(TEMPLATES_PATH, costing_data.template_providers, overrides)
     figures = combine_figures(costing_data.template_providers)
-    included_files = get_local_included_files_map(INCLUDED_FILES_PATH, LOCAL_INCLUDED_FILES)
+    included_files = get_local_included_files_map(INCLUDED_FILES_PATH, LOCAL_INCLUDED_FILES, overrides)
     return ReportContent(document_template, hydrated_templates, included_files, figures)
-
-
-def load_document_template() -> HydratedTemplate:
-    return HydratedTemplate(
-        TemplateProvider(template_file=DOCUMENT_TEMPLATE),
-        read_template(TEMPLATES_PATH, DOCUMENT_TEMPLATE)
-    )

--- a/pyfecons/costing/mfe/mfe.py
+++ b/pyfecons/costing/mfe/mfe.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 from pyfecons.enums import ReactorType
 from pyfecons.helpers import get_local_included_files_map
-from pyfecons.templates import read_template, hydrate_templates, combine_figures
+from pyfecons.templates import hydrate_templates, combine_figures, load_document_template
 from pyfecons.inputs import Inputs
-from pyfecons.data import Data, TemplateProvider
+from pyfecons.data import Data
 from pyfecons.costing.mfe.PowerBalance import power_balance
 from pyfecons.costing.mfe.CAS10 import cas_10
 from pyfecons.costing.mfe.CAS21 import cas_21
@@ -41,7 +43,7 @@ from pyfecons.costing.mfe.CAS80 import cas_80
 from pyfecons.costing.mfe.CAS90 import cas_90
 from pyfecons.costing.mfe.LCOE import lcoe
 from pyfecons.costing.mfe.CostTable import cost_table
-from pyfecons.report import ReportContent, CostingData, HydratedTemplate
+from pyfecons.report import ReportContent, CostingData, ReportOverrides
 
 TEMPLATES_PATH = 'pyfecons.costing.mfe.templates'
 INCLUDED_FILES_PATH = 'pyfecons.costing.mfe.included_files'
@@ -114,16 +116,10 @@ def GenerateCostingData(inputs: Inputs) -> CostingData:
     return CostingData(data, template_providers)
 
 
-def load_document_template() -> HydratedTemplate:
-    return HydratedTemplate(
-        TemplateProvider(template_file=DOCUMENT_TEMPLATE),
-        read_template(TEMPLATES_PATH, DOCUMENT_TEMPLATE)
-    )
-
-
-def CreateReportContent(costing_data: CostingData) -> ReportContent:
-    document_template = load_document_template()
-    hydrated_templates = hydrate_templates(TEMPLATES_PATH, costing_data.template_providers)
+def CreateReportContent(costing_data: CostingData,
+                        overrides: Optional[ReportOverrides] = None) -> ReportContent:
+    document_template = load_document_template(TEMPLATES_PATH, DOCUMENT_TEMPLATE, overrides)
+    hydrated_templates = hydrate_templates(TEMPLATES_PATH, costing_data.template_providers, overrides)
     figures = combine_figures(costing_data.template_providers)
-    included_files = get_local_included_files_map(INCLUDED_FILES_PATH, LOCAL_INCLUDED_FILES)
+    included_files = get_local_included_files_map(INCLUDED_FILES_PATH, LOCAL_INCLUDED_FILES, overrides)
     return ReportContent(document_template, hydrated_templates, included_files, figures)

--- a/pyfecons/pyfecons.py
+++ b/pyfecons/pyfecons.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import subprocess
 import tempfile
-
+from typing import Optional
 from pyfecons.helpers import base_name_without_extension
 from pyfecons.inputs import Inputs
 from pyfecons.enums import *
@@ -10,7 +10,7 @@ from pyfecons.costing.mfe.mfe import GenerateCostingData as GenerateMfeCostingDa
 from pyfecons.costing.mfe.mfe import CreateReportContent as CreateMfeReport
 from pyfecons.costing.ife.ife import GenerateCostingData as GenerateIfeCostingData
 from pyfecons.costing.ife.ife import CreateReportContent as CreateIfeReport
-from pyfecons.report import ReportContent, FinalReport, CostingData
+from pyfecons.report import ReportContent, FinalReport, CostingData, ReportOverrides
 
 
 def RunCosting(inputs: Inputs) -> CostingData:
@@ -23,17 +23,19 @@ def RunCosting(inputs: Inputs) -> CostingData:
     raise ValueError('Invalid basic reactor type')
 
 
-def CreateReportContent(inputs: Inputs, costing_data: CostingData) -> ReportContent:
+def CreateReportContent(inputs: Inputs, costing_data: CostingData
+                        , overrides: Optional[ReportOverrides] = None) -> ReportContent:
     """
     Create report content with given cost calculation inputs and output data.
     :param inputs: The inputs used for cost calculations.
     :param costing_data: The output data and templates providers for cost calculations.
+    :param overrides: Overriding substitutions for latex template hydration.
     :return: Report contents including files, hydrated templates, and latex packages.
     """
     if inputs.basic.reactor_type == ReactorType.MFE:
-        return CreateMfeReport(costing_data)
+        return CreateMfeReport(costing_data, overrides)
     elif inputs.basic.reactor_type == ReactorType.IFE:
-        return CreateIfeReport(costing_data)
+        return CreateIfeReport(costing_data, overrides)
     elif inputs.basic.reactor_type == ReactorType.MIF:
         raise NotImplementedError()
     raise ValueError('Invalid basic reactor type')

--- a/pyfecons/report.py
+++ b/pyfecons/report.py
@@ -25,7 +25,7 @@ class ReportContent:
     document_template: HydratedTemplate = None
     # Hydrated templates to be included in tex compilation
     hydrated_templates: list[HydratedTemplate] = field(default_factory=list)
-    # tex file path -> local file path of files to include in tex compilation
+    # tex file path -> absolute path of files to include in tex compilation
     included_files: dict[str, str] = field(default_factory=dict)
     # latex path -> image bytes
     figures: dict[str, bytes] = field(default_factory=dict)
@@ -35,3 +35,11 @@ class ReportContent:
 class FinalReport:
     report_tex: str
     report_pdf: bytes
+
+
+@dataclass
+class ReportOverrides:
+    # tex_file_path -> absolute path of included_file to be overridden
+    included_files: dict[str, str] = field(default_factory=dict)
+    # template_filename -> contents of templates to be overridden in hydration
+    templates: dict[str, str] = field(default_factory=dict)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt', encoding='utf-8') as f:
 
 setup(
     name='pyfecons',
-    version='0.0.28',
+    version='0.0.29',
     author='nTtau Digital LTD',
     author_email='info@nttaudigital.com',
     description='Library for nTtau PyFECONS costing calculations.',


### PR DESCRIPTION
Closes issue https://github.com/Woodruff-Scientific-Ltd/PyFECONS/issues/38. 

Allow customization of reports by replacing templates and included_files of the same name in the customer directory.

In the following example `StandardFigures/WSLTD_logo.png` and `CAS100000.tex` will use substitution in customer folder over the ones in the included_files and templates in the library.

Customer directory structure with overrides:
<img width="260" alt="Screenshot 2024-06-11 at 10 58 43" src="https://github.com/Woodruff-Scientific-Ltd/PyFECONS/assets/431915/2d25377c-114f-48e1-8fea-8704208806fd">

Replaced logo:
<img width="443" alt="Screenshot 2024-06-11 at 10 47 54" src="https://github.com/Woodruff-Scientific-Ltd/PyFECONS/assets/431915/85a59760-e9d6-4e9b-a77b-fa21463b067b">

Replaced template:
<img width="510" alt="Screenshot 2024-06-11 at 10 48 10" src="https://github.com/Woodruff-Scientific-Ltd/PyFECONS/assets/431915/5533be5d-f7a8-46b5-a9fd-b6b0f5392539">

Other changes
* Fixed warning in CAS220107.py trying to show plot in headless environment
* Extracted common code in loading document template
* RunForCustomers loads overrides and passes them throughout generating report content