### PR TITLE
Downgrade to Python 3.10 for Colab

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ Windows
 TODO
 ```
 
-### Installing Python 3.11
+### Installing Python 3.10
 
-Library is tested working with Python 3.11 (3.11.9).
+Library is tested working with Python 3.10 (3.10.14).
 
 We recommend [pyenv](https://github.com/pyenv/pyenv) for Python version management on MacOS / Linux and [pyenv-win](https://github.com/pyenv-win/pyenv-win) for Windows.
 
@@ -131,10 +131,10 @@ echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zsh
 echo 'eval "$(pyenv init -)"' >> ~/.zshrc
 
 # install python version
-pyenv install 3.11.9
+pyenv install 3.10
 
 # optional, set it as global version
-pyenv global 3.11.9
+pyenv global 3.10
 
 # verify python version
 python3 --version

--- a/deployment/python/README.md
+++ b/deployment/python/README.md
@@ -6,9 +6,9 @@ _Characterizing fusion market entry via an agent-based power plant fleet model_ 
 
 All commands in this README should be run in the `PyFECONs/deployment/python/` directory.
 
-## Install Python 3.11
+## Install Python 3.10
 
-Follow the steps in [Installing Python 3.11](../../README.md#installing-python-311). 
+Follow the steps in [Installing Python 3.10](../../README.md#installing-python-310). 
 
 ## Install dependencies with pip & venv
 
@@ -25,11 +25,11 @@ python3 -m venv venv
 # activate virtual environment (on new terminal)
 source venv/bin/activate
 
-# deactivate virtual environment (after activating)
-deactivate
-
 # install dependencies (on new environment or after changes)
 pip install -r requirements.txt
+
+# deactivate virtual environment (after activating)
+deactivate
 ```
 
 Windows Commands

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt', encoding='utf-8') as f:
 
 setup(
     name='pyfecons',
-    version='0.0.35',
+    version='0.0.36',
     author='Woodruff Scientific LTD',
     author_email='info@woodruffscientific.com',
     description='Library for PyFECONS costing calculations.',
@@ -18,8 +18,8 @@ setup(
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.10',
     ],
-    python_requires='>=3.11',
+    python_requires='>=3.10',
     include_package_data=True,
 )


### PR DESCRIPTION
[Google Colab](https://colab.research.google.com/) uses Python 3.10 without a good way to upgrade. Since the library doesn't use anything specific from Python 3.11 we can just downgrade. Costing and deployment code were tested and working with Python 3.10.14.