### PR TITLE
Fix cost calculations for FliBe first wall

### DIFF
--- a/customers/CATF/ife/inputs.json
+++ b/customers/CATF/ife/inputs.json
@@ -327,8 +327,8 @@
             "name": "Lithium Fluoride (LiF) and Beryllium Fluoride (BeF2) Mixture",
             "rho": 1900,
             "c": 40,
-            "c_raw": null,
-            "m": null,
+            "c_raw": 1000,
+            "m": 1,
             "sigma": null
         },
         "W": {

--- a/customers/CATF/mfe/inputs.json
+++ b/customers/CATF/mfe/inputs.json
@@ -572,8 +572,8 @@
             "name": "Lithium Fluoride (LiF) and Beryllium Fluoride (BeF2) Mixture",
             "rho": 1900,
             "c": 40,
-            "c_raw": null,
-            "m": null,
+            "c_raw": 1000,
+            "m": 1,
             "sigma": null
         },
         "W": {

--- a/pyfecons/costing/calculations/cas22/cas220101_reactor_equipment.py
+++ b/pyfecons/costing/calculations/cas22/cas220101_reactor_equipment.py
@@ -187,7 +187,7 @@ def compute_blanket_costs(blanket: Blanket, OUT: CAS220101) -> M_USD:
     raise f'Unknown blanket type {blanket.blanket_type}'
 
 
-def compute_material_cost(volume: float, material: Material) -> M_USD:
+def compute_material_cost(volume: Meters3, material: Material) -> M_USD:
     return to_m_usd(volume * material.rho * material.c_raw * material.m)
 
 

--- a/pyfecons/materials.py
+++ b/pyfecons/materials.py
@@ -16,7 +16,8 @@ class Materials:
         self.FS = Material(name="Ferritic Steel", rho=7470, c_raw=10, m=3, sigma=450)
         self.Pb = Material(name="Lead", rho=9400, c_raw=2.4, m=1.5)
         self.Li4SiO4 = Material(name="Lithium Silicate", rho=2390, c_raw=1, m=2)
-        self.FliBe = Material(name="Lithium Fluoride (LiF) and Beryllium Fluoride (BeF2) Mixture", rho=1900, c=40)
+        # TODO figure out actual value c_raw and m for FliBe, these are currently placeholders
+        self.FliBe = Material(name="Lithium Fluoride (LiF) and Beryllium Fluoride (BeF2) Mixture", rho=1900, c=40, c_raw=1000, m=1)
         self.W = Material(name="Tungsten", rho=19300, c_raw=100, m=3)
         self.Li = Material(name="Lithium", rho=534, c_raw=70, m=1.5)
         self.BFS = Material(name="BFS", rho=7800, c_raw=30, m=2)

--- a/pyfecons/materials.py
+++ b/pyfecons/materials.py
@@ -1,14 +1,16 @@
 from dataclasses import dataclass
 
+from pyfecons.units import KG_M3, USD_M3, USD_KG, Megapascal
+
 
 @dataclass
 class Material:
     name: str = None
-    rho: float = None
-    c: float = None
-    c_raw: float = None
-    m: float = None
-    sigma: int = None
+    rho: KG_M3 = None  # Density
+    c: USD_M3 = None  # Cost per unit volume
+    c_raw: USD_KG = None  # Cost per unit mass
+    m: float = None  # Mass factor or multiplier (unitless) - TODO clarify this unit
+    sigma: Megapascal = None
 
 
 class Materials:

--- a/pyfecons/units.py
+++ b/pyfecons/units.py
@@ -125,3 +125,27 @@ class USD_W(float):
 class V(float):
     def __str__(self):
         return f"{self:.2f}"
+
+# Density - kg/m^3
+class KG_M3(float):
+    def __str__(self):
+        return f"{self:.2f}"
+
+
+# Cost per unit volume - USD/m^3
+class USD_M3(float):
+    def __str__(self):
+        return f"{self:.2f}"
+
+
+# Cost per unit mass - USD/kg
+class USD_KG(float):
+    def __str__(self):
+        return f"{self:.2f}"
+
+
+# unit of pressure or stress - N/m^2
+class Megapascal(float):
+    def __str__(self):
+        return f"{self:.2f}"
+

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt', encoding='utf-8') as f:
 
 setup(
     name='pyfecons',
-    version='0.0.37',
+    version='0.0.38',
     author='Woodruff Scientific LTD',
     author_email='info@woodruffscientific.com',
     description='Library for PyFECONS costing calculations.',


### PR DESCRIPTION
In investigating Issue https://github.com/Woodruff-Scientific-Ltd/PyFECONS/issues/65, we discovered the cause was Material FliBe missing c_raw and m. We added placeholder values so the cost calculations would run. These will need to be verified in Issue https://github.com/Woodruff-Scientific-Ltd/PyFECONS/issues/54.

Changes
* Added FliBe c_raw=1000 and m=1
* Made a best guess to define units for Material properties
* Added volume input unit in reactor material cost calculation

GPT thread to help reason about this issue:
https://chatgpt.com/share/2dbcf6bf-fd4b-4320-96d8-8cc63973c428