### PR TITLE
Rename reactor type to fusion machine type

### DIFF
--- a/customers/CATF/ife/DefineInputs.py
+++ b/customers/CATF/ife/DefineInputs.py
@@ -28,7 +28,7 @@ def Generate() -> AllInputs:
     return AllInputs(
         customer_info=CustomerInfo(name="Clean Air Task Force"),
         basic=Basic(
-            reactor_type=ReactorType.IFE,
+            fusion_machine_type=FusionMachineType.IFE,
             confinement_type=ConfinementType.LASER_DRIVEN_DIRECT_DRIVE,
             energy_conversion=EnergyConversion.DIRECT,
             fuel_type=FuelType.PB11,

--- a/customers/CATF/ife/data.json
+++ b/customers/CATF/ife/data.json
@@ -1,5 +1,5 @@
 {
-    "reactor_type": "IFE",
+    "fusion_machine_type": "IFE",
     "power_table": {
         "p_alpha": 2500.0,
         "p_neutron": 0.0,

--- a/customers/CATF/ife/inputs.json
+++ b/customers/CATF/ife/inputs.json
@@ -3,7 +3,7 @@
         "name": "Clean Air Task Force"
     },
     "basic": {
-        "reactor_type": "IFE",
+        "fusion_machine_type": "IFE",
         "confinement_type": "LASER_DRIVEN_DIRECT_DRIVE",
         "energy_conversion": "DIRECT",
         "fuel_type": "PB11",

--- a/customers/CATF/mfe/DefineInputs.py
+++ b/customers/CATF/mfe/DefineInputs.py
@@ -26,7 +26,7 @@ def Generate() -> AllInputs:
     return AllInputs(
         customer_info=CustomerInfo(name="Clean Air Task Force"),
         basic=Basic(
-            reactor_type=ReactorType.MFE,
+            fusion_machine_type=FusionMachineType.MFE,
             confinement_type=ConfinementType.SPHERICAL_TOKAMAK,
             energy_conversion=EnergyConversion.DIRECT,
             fuel_type=FuelType.DT,

--- a/customers/CATF/mfe/data.json
+++ b/customers/CATF/mfe/data.json
@@ -1,5 +1,5 @@
 {
-    "reactor_type": "MFE",
+    "fusion_machine_type": "MFE",
     "power_table": {
         "p_alpha": 520.5915813424347,
         "p_neutron": 2079.4084186575656,

--- a/customers/CATF/mfe/inputs.json
+++ b/customers/CATF/mfe/inputs.json
@@ -3,7 +3,7 @@
         "name": "Clean Air Task Force"
     },
     "basic": {
-        "reactor_type": "MFE",
+        "fusion_machine_type": "MFE",
         "confinement_type": "SPHERICAL_TOKAMAK",
         "energy_conversion": "DIRECT",
         "fuel_type": "DT",

--- a/pyfecons/README.md
+++ b/pyfecons/README.md
@@ -36,7 +36,7 @@ The main machinery here is as follows:
 
 ```
 def GenerateCostingData(inputs: AllInputs) -> CostingData
-    data = Data(reactor_type=ReactorType.IFE)
+    data = Data(fusion_machine_type=FusionMachineType.IFE)
     template_providers = [
         power_balance(inputs, data),
         cas_10(inputs, data),

--- a/pyfecons/costing/calculations/cas21_buildings.py
+++ b/pyfecons/costing/calculations/cas21_buildings.py
@@ -1,7 +1,7 @@
 from pyfecons.costing.accounting.power_table import PowerTable
 from pyfecons.costing.calculations.conversions import k_to_m_usd
 from pyfecons.costing.categories.cas210000 import CAS21
-from pyfecons.enums import FuelType, ReactorType
+from pyfecons.enums import FuelType, FusionMachineType
 from pyfecons.inputs.basic import Basic
 from pyfecons.units import M_USD
 
@@ -17,7 +17,9 @@ def cas_21_building_costs(basic: Basic, power_table: PowerTable) -> CAS21:
     # [2] Waganer, L.M., 2013. ARIES cost account documentation. San Diego: University of California.
 
     # 0.5 from lack of Tritium - we don't need so much structure in the containment building.
-    fuel_scaling_factor = get_fuel_scaling_factor(basic.reactor_type, basic.fuel_type)
+    fuel_scaling_factor = get_fuel_scaling_factor(
+        basic.fusion_machine_type, basic.fuel_type
+    )
 
     # 21.01.00,,Site improvements and facs. Source: [1] cost account 13, page 134
     cas21.C210100 = M_USD(k_to_m_usd(268) * p_et * fuel_scaling_factor)
@@ -101,8 +103,10 @@ def cas_21_building_costs(basic: Basic, power_table: PowerTable) -> CAS21:
     return cas21
 
 
-def get_fuel_scaling_factor(reactor_type: ReactorType, fuel_type: FuelType):
-    if reactor_type != ReactorType.MFE:
+def get_fuel_scaling_factor(
+    fusion_machine_type: FusionMachineType, fuel_type: FuelType
+):
+    if fusion_machine_type != FusionMachineType.MFE:
         return 1.0
     if fuel_type == FuelType.DT:
         return 1.0

--- a/pyfecons/costing/calculations/cas22/cas220102_shield.py
+++ b/pyfecons/costing/calculations/cas22/cas220102_shield.py
@@ -1,7 +1,7 @@
 from pyfecons.costing.calculations.conversions import k_to_m_usd
 from pyfecons.costing.categories.cas220101 import CAS220101
 from pyfecons.costing.categories.cas220102 import CAS220102
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.inputs.basic import Basic
 from pyfecons.inputs.blanket import Blanket
 from pyfecons.inputs.shield import Shield
@@ -15,7 +15,7 @@ def cas_220102_shield_costs(
     basic: Basic, shield: Shield, blanket: Blanket, cas220101: CAS220101
 ) -> CAS220102:
     # Cost Category 22.1.2: Shield
-    reactor_type = basic.reactor_type
+    fusion_machine_type = basic.fusion_machine_type
     cas220102 = CAS220102()
 
     # Retrieve the volume of HTS from the reactor_volumes dictionary
@@ -40,7 +40,7 @@ def cas_220102_shield_costs(
 
     # The cost C_22_1_2 is the same as C_HTS
     # TODO what's the *5 for?
-    c_hts_scaling = 5.0 if reactor_type == ReactorType.IFE else 1.0
+    c_hts_scaling = 5.0 if fusion_machine_type == FusionMachineType.IFE else 1.0
     cas220102.C22010201 = M_USD(round(C_HTS * c_hts_scaling, 1))
     cas220102.C22010202 = k_to_m_usd(
         cas220101.lt_shield_vol * materials.SS316.c_raw * materials.SS316.m

--- a/pyfecons/costing/ife/ife.py
+++ b/pyfecons/costing/ife/ife.py
@@ -91,12 +91,12 @@ from pyfecons.costing.ife.cas22.cas220108_target_factory import (
 from pyfecons.costing.ife.cas80_annualized_fuel import cas80_annualized_fuel_costs
 from pyfecons.costing.ife.PowerBalance import power_balance
 from pyfecons.costing_data import CostingData
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.inputs.all_inputs import AllInputs
 
 
 def GenerateCostingData(inputs: AllInputs) -> CostingData:
-    data = CostingData(reactor_type=ReactorType.IFE)
+    data = CostingData(fusion_machine_type=FusionMachineType.IFE)
     data.power_table = power_balance(inputs.basic, inputs.power_input)
     data.cas10 = cas_10_pre_construction_costs(inputs.basic, data.power_table)
     data.cas21 = cas_21_building_costs(inputs.basic, data.power_table)

--- a/pyfecons/costing/mfe/mfe.py
+++ b/pyfecons/costing/mfe/mfe.py
@@ -89,12 +89,12 @@ from pyfecons.costing.mfe.cas22.cas220108_divertor import cas_220108_divertor_co
 from pyfecons.costing.mfe.cas80_annualized_fuel import cas80_annualized_fuel_costs
 from pyfecons.costing.mfe.PowerBalance import power_balance
 from pyfecons.costing_data import CostingData
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.inputs.all_inputs import AllInputs
 
 
 def GenerateCostingData(inputs: AllInputs) -> CostingData:
-    data = CostingData(reactor_type=ReactorType.MFE)
+    data = CostingData(fusion_machine_type=FusionMachineType.MFE)
     data.power_table = power_balance(inputs.basic, inputs.power_input)
     data.cas10 = cas_10_pre_construction_costs(inputs.basic, data.power_table)
     data.cas21 = cas_21_building_costs(inputs.basic, data.power_table)

--- a/pyfecons/costing_data.py
+++ b/pyfecons/costing_data.py
@@ -46,14 +46,14 @@ from pyfecons.costing.categories.cas700000 import CAS70
 from pyfecons.costing.categories.cas800000 import CAS80
 from pyfecons.costing.categories.cas900000 import CAS90
 from pyfecons.costing.categories.lcoe import LCOE
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.serializable import SerializableToJSON
 from pyfecons.units import M_USD
 
 
 @dataclass
 class CostingData(SerializableToJSON):
-    reactor_type: ReactorType
+    fusion_machine_type: FusionMachineType
     power_table: PowerTable = field(default_factory=PowerTable)
     cas10: CAS10 = field(default_factory=CAS10)
     cas21: CAS21 = field(default_factory=CAS21)
@@ -104,9 +104,9 @@ class CostingData(SerializableToJSON):
             self.cas220108 = self._initialize_cas220108()
 
     def _initialize_cas220103(self) -> Union[CAS220103Coils, CAS220103Lasers]:
-        if self.reactor_type == ReactorType.MFE:
+        if self.fusion_machine_type == FusionMachineType.MFE:
             return CAS220103Coils()
-        elif self.reactor_type == ReactorType.IFE:
+        elif self.fusion_machine_type == FusionMachineType.IFE:
             return CAS220103Lasers()
         else:  # mif
             raise ValueError("Invalid reactor type. 'mif' is not yet supported.")
@@ -114,17 +114,17 @@ class CostingData(SerializableToJSON):
     def _initialize_cas220104(
         self,
     ) -> Union[CAS220104SupplementaryHeating, CAS220104IgnitionLasers]:
-        if self.reactor_type == ReactorType.MFE:
+        if self.fusion_machine_type == FusionMachineType.MFE:
             return CAS220104SupplementaryHeating()
-        elif self.reactor_type == ReactorType.IFE:
+        elif self.fusion_machine_type == FusionMachineType.IFE:
             return CAS220104IgnitionLasers()
         else:  # mif
             raise ValueError("Invalid reactor type. 'mif' is not yet supported.")
 
     def _initialize_cas220108(self) -> Union[CAS220108Divertor, CAS220108TargetFactory]:
-        if self.reactor_type == ReactorType.MFE:
+        if self.fusion_machine_type == FusionMachineType.MFE:
             return CAS220108Divertor()
-        elif self.reactor_type == ReactorType.IFE:
+        elif self.fusion_machine_type == FusionMachineType.IFE:
             return CAS220108TargetFactory()
         else:  # mif
             raise ValueError("Invalid reactor type. 'mif' is not yet supported.")

--- a/pyfecons/enums.py
+++ b/pyfecons/enums.py
@@ -1,35 +1,35 @@
 from enum import Enum
 
 
-class ReactorType(Enum):
+class FusionMachineType(Enum):
     IFE = "IFE"
     MFE = "MFE"
     MIF = "MIF"
 
 
 class ConfinementType(Enum):
-    # STELLARATOR = (ReactorType.MFE, 'STELLARATOR')
-    SPHERICAL_TOKAMAK = (ReactorType.MFE, "SPHERICAL_TOKAMAK")
-    # CONVENTIONAL_TOKAMAK = (ReactorType.MFE, 'CONVENTIONAL_TOKAMAK')
-    # COMPACT_TOKAMAK = (ReactorType.MFE, 'COMPACT_TOKAMAK')
-    MAGNETIC_MIRROR = (ReactorType.MFE, "MAGNETIC_MIRROR")
-    # SPHEROMAK = (ReactorType.MFE, 'SPHEROMAK')
-    # RFP = (ReactorType.MFE, 'RFP')
-    # FRC = (ReactorType.MFE, 'FRC')
-    # MAG_LIF = (ReactorType.MIF, 'MAG_LIF')
-    # Z_PINCH = (ReactorType.MIF, 'Z_PINCH')
-    # PLASMA_JET = (ReactorType.MIF, 'PLASMA_JET')
-    # MIRROR_MIF = (ReactorType.MIF, 'MIRROR_MIF')
-    # THETA_PINCH = (ReactorType.MIF, 'THETA_PINCH')
-    LASER_DRIVEN_DIRECT_DRIVE = (ReactorType.IFE, "LASER_DRIVEN_DIRECT_DRIVE")
-    # LASER_DRIVEN_INDIRECT_DRIVE = (ReactorType.IFE, 'LASER_DRIVEN_INDIRECT_DRIVE')
-    # FAST_IGNITION = (ReactorType.IFE, 'FAST_IGNITION')
-    # IEC = (ReactorType.IFE, 'IEC')
-    # PROJECTILE = (ReactorType.IFE, 'PROJECTILE')
+    # STELLARATOR = (FusionMachineType.MFE, 'STELLARATOR')
+    SPHERICAL_TOKAMAK = (FusionMachineType.MFE, "SPHERICAL_TOKAMAK")
+    # CONVENTIONAL_TOKAMAK = (FusionMachineType.MFE, 'CONVENTIONAL_TOKAMAK')
+    # COMPACT_TOKAMAK = (FusionMachineType.MFE, 'COMPACT_TOKAMAK')
+    MAGNETIC_MIRROR = (FusionMachineType.MFE, "MAGNETIC_MIRROR")
+    # SPHEROMAK = (FusionMachineType.MFE, 'SPHEROMAK')
+    # RFP = (FusionMachineType.MFE, 'RFP')
+    # FRC = (FusionMachineType.MFE, 'FRC')
+    # MAG_LIF = (FusionMachineType.MIF, 'MAG_LIF')
+    # Z_PINCH = (FusionMachineType.MIF, 'Z_PINCH')
+    # PLASMA_JET = (FusionMachineType.MIF, 'PLASMA_JET')
+    # MIRROR_MIF = (FusionMachineType.MIF, 'MIRROR_MIF')
+    # THETA_PINCH = (FusionMachineType.MIF, 'THETA_PINCH')
+    LASER_DRIVEN_DIRECT_DRIVE = (FusionMachineType.IFE, "LASER_DRIVEN_DIRECT_DRIVE")
+    # LASER_DRIVEN_INDIRECT_DRIVE = (FusionMachineType.IFE, 'LASER_DRIVEN_INDIRECT_DRIVE')
+    # FAST_IGNITION = (FusionMachineType.IFE, 'FAST_IGNITION')
+    # IEC = (FusionMachineType.IFE, 'IEC')
+    # PROJECTILE = (FusionMachineType.IFE, 'PROJECTILE')
 
-    def __new__(cls, reactor_type: ReactorType, value):
+    def __new__(cls, fusion_machine_type: FusionMachineType, value):
         obj = object.__new__(cls)
-        obj.reactor_type = reactor_type
+        obj.fusion_machine_type = fusion_machine_type
         obj._value_ = value
         return obj
 

--- a/pyfecons/figures/radial_build.py
+++ b/pyfecons/figures/radial_build.py
@@ -3,7 +3,7 @@ from io import BytesIO
 import matplotlib
 import matplotlib.pyplot as plt
 
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.inputs.radial_build import RadialBuild
 
 matplotlib.use("Agg")
@@ -13,12 +13,14 @@ class RadialBuildFigure:
     """Class for generating radial build plots."""
 
     @staticmethod
-    def create(reactor_type: ReactorType, radial_build: RadialBuild) -> bytes:
+    def create(
+        fusion_machine_type: FusionMachineType, radial_build: RadialBuild
+    ) -> bytes:
         """
         Plot the radial build of the reactor.
 
         Args:
-            reactor_type: The type of reactor (MFE or IFE)
+            fusion_machine_type: The type of reactor (MFE or IFE)
             radial_build: The radial build data
 
         Returns:
@@ -39,7 +41,7 @@ class RadialBuildFigure:
             "Vessel",
             "LT Shield",
             *(
-                ["Coil"] if reactor_type == ReactorType.MFE else []
+                ["Coil"] if fusion_machine_type == FusionMachineType.MFE else []
             ),  # include only for MFE
             "Gap",
             "Bioshield",
@@ -58,7 +60,7 @@ class RadialBuildFigure:
             IN.vessel_t,
             IN.lt_shield_t,
             *(
-                [IN.coil_t] if reactor_type == ReactorType.MFE else []
+                [IN.coil_t] if fusion_machine_type == FusionMachineType.MFE else []
             ),  # include only for MFE
             IN.gap2_t,
             IN.bioshield_t,
@@ -77,7 +79,7 @@ class RadialBuildFigure:
             "orange",
             "slateblue",
             *(
-                ["green"] if reactor_type == ReactorType.MFE else []
+                ["green"] if fusion_machine_type == FusionMachineType.MFE else []
             ),  # include only for MFE
             "lightgray",
             "darkorange",

--- a/pyfecons/functions.py
+++ b/pyfecons/functions.py
@@ -1,19 +1,19 @@
 from pyfecons.costing.calculations.cas22.cas220101_reactor_equipment import (
     compute_reactor_equipment_costs,
 )
-from pyfecons.enums import ConfinementType, ReactorType
+from pyfecons.enums import ConfinementType, FusionMachineType
 from pyfecons.inputs.blanket import Blanket
 from pyfecons.inputs.radial_build import RadialBuild
 from pyfecons.units import M_USD
 
 
 def compute_cas22_reactor_equipment_total_cost(
-    reactor_type: ReactorType,
+    fusion_machine_type: FusionMachineType,
     confinement_type: ConfinementType,
     blanket: Blanket,
     radial_build: RadialBuild,
 ) -> M_USD:
     result = compute_reactor_equipment_costs(
-        reactor_type, confinement_type, blanket, radial_build
+        fusion_machine_type, confinement_type, blanket, radial_build
     )
     return result.C220101

--- a/pyfecons/inputs/basic.py
+++ b/pyfecons/inputs/basic.py
@@ -1,12 +1,17 @@
 from dataclasses import dataclass
 
-from pyfecons.enums import ConfinementType, EnergyConversion, FuelType, ReactorType
+from pyfecons.enums import (
+    ConfinementType,
+    EnergyConversion,
+    FuelType,
+    FusionMachineType,
+)
 from pyfecons.units import HZ, MW, Count, Percent, Years
 
 
 @dataclass
 class Basic:
-    reactor_type: ReactorType = None
+    fusion_machine_type: FusionMachineType = None
     confinement_type: ConfinementType = None
     energy_conversion: EnergyConversion = None
     fuel_type: FuelType = FuelType.DT

--- a/pyfecons/pyfecons.py
+++ b/pyfecons/pyfecons.py
@@ -16,11 +16,11 @@ from pyfecons.report.mfe_report import CreateReportContent as CreateMfeReport
 
 
 def RunCosting(inputs: AllInputs) -> CostingData:
-    if inputs.basic.reactor_type == ReactorType.MFE:
+    if inputs.basic.fusion_machine_type == FusionMachineType.MFE:
         return GenerateMfeCostingData(inputs)
-    elif inputs.basic.reactor_type == ReactorType.IFE:
+    elif inputs.basic.fusion_machine_type == FusionMachineType.IFE:
         return GenerateIfeCostingData(inputs)
-    elif inputs.basic.reactor_type == ReactorType.MIF:
+    elif inputs.basic.fusion_machine_type == FusionMachineType.MIF:
         raise NotImplementedError()
     raise ValueError("Invalid basic reactor type")
 
@@ -37,11 +37,11 @@ def CreateReportContent(
     :param overrides: Overriding substitutions for latex template hydration.
     :return: Report contents including files, hydrated templates, and latex packages.
     """
-    if costing_data.reactor_type == ReactorType.MFE:
+    if costing_data.fusion_machine_type == FusionMachineType.MFE:
         return CreateMfeReport(inputs, costing_data, overrides)
-    elif costing_data.reactor_type == ReactorType.IFE:
+    elif costing_data.fusion_machine_type == FusionMachineType.IFE:
         return CreateIfeReport(inputs, costing_data, overrides)
-    elif costing_data.reactor_type == ReactorType.MIF:
+    elif costing_data.fusion_machine_type == FusionMachineType.MIF:
         raise NotImplementedError()
     raise ValueError("Invalid reactor type")
 

--- a/pyfecons/report/sections/cas220101_section.py
+++ b/pyfecons/report/sections/cas220101_section.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Dict
 
 from pyfecons.costing.categories.cas220101 import CAS220101
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.figures import RadialBuildFigure
 from pyfecons.inputs.basic import Basic
 from pyfecons.inputs.blanket import Blanket
@@ -10,16 +10,19 @@ from pyfecons.inputs.radial_build import RadialBuild
 from pyfecons.report.section import ReportSection
 
 
-def get_template_file(reactor_type: ReactorType):
-    if reactor_type == ReactorType.MFE:
+def get_template_file(fusion_machine_type: FusionMachineType):
+    if fusion_machine_type == FusionMachineType.MFE:
         return "CAS220101_MFE_DT.tex"
-    if reactor_type == ReactorType.IFE:
+    if fusion_machine_type == FusionMachineType.IFE:
         return "CAS220101_IFE_DT.tex"
-    raise ValueError(f"Unsupported reactor type {reactor_type}")
+    raise ValueError(f"Unsupported reactor type {fusion_machine_type}")
 
 
 def compute_220101_replacements(
-    reactor_type: ReactorType, blanket: Blanket, IN: RadialBuild, OUT: CAS220101
+    fusion_machine_type: FusionMachineType,
+    blanket: Blanket,
+    IN: RadialBuild,
+    OUT: CAS220101,
 ) -> Dict[str, str]:
     rounding = 2
     return {
@@ -43,7 +46,7 @@ def compute_220101_replacements(
         "TH10": round(IN.lt_shield_t, rounding),
         **(
             {"TH11": round(IN.coil_t, rounding)}
-            if reactor_type == ReactorType.MFE
+            if fusion_machine_type == FusionMachineType.MFE
             else {}
         ),
         "TH12": round(IN.axis_t, rounding),
@@ -61,7 +64,7 @@ def compute_220101_replacements(
         "RAD10I": round(OUT.lt_shield_ir, rounding),
         **(
             {"RAD11I": round(OUT.coil_ir, rounding)}
-            if reactor_type == ReactorType.MFE
+            if fusion_machine_type == FusionMachineType.MFE
             else {}
         ),
         "RAD12I": round(OUT.axis_ir, rounding),
@@ -79,7 +82,7 @@ def compute_220101_replacements(
         "RAD10O": round(OUT.lt_shield_or, rounding),
         **(
             {"RAD11O": round(OUT.coil_or, rounding)}
-            if reactor_type == ReactorType.MFE
+            if fusion_machine_type == FusionMachineType.MFE
             else {}
         ),
         "RAD12O": round(OUT.axis_or, rounding),
@@ -97,7 +100,7 @@ def compute_220101_replacements(
         "VOL10": round(OUT.lt_shield_vol, rounding),
         **(
             {"VOL11": round(OUT.coil_vol, rounding)}
-            if reactor_type == ReactorType.MFE
+            if fusion_machine_type == FusionMachineType.MFE
             else {}
         ),
         "VOL12": round(OUT.axis_vol, rounding),
@@ -116,10 +119,10 @@ class CAS220101Section(ReportSection):
         blanket: Blanket,
     ):
         super().__init__()
-        self.template_file = get_template_file(basic.reactor_type)
+        self.template_file = get_template_file(basic.fusion_machine_type)
         self.figures["Figures/radial_build.pdf"] = RadialBuildFigure.create(
-            basic.reactor_type, radial_build
+            basic.fusion_machine_type, radial_build
         )
         self.replacements = compute_220101_replacements(
-            basic.reactor_type, blanket, radial_build, cas220101
+            basic.fusion_machine_type, blanket, radial_build, cas220101
         )

--- a/pyfecons/report/sections/cas220102_section.py
+++ b/pyfecons/report/sections/cas220102_section.py
@@ -2,13 +2,13 @@ from dataclasses import dataclass
 from typing import Any, Dict
 
 from pyfecons.costing.categories.cas220102 import CAS220102
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.report.section import ReportSection
 
 
 @dataclass
 class CAS220102Section(ReportSection):
-    def __init__(self, cas220102: CAS220102, reactor_type: ReactorType):
+    def __init__(self, cas220102: CAS220102, fusion_machine_type: FusionMachineType):
         super().__init__()
         self.template_file = "CAS220102.tex"
 
@@ -24,7 +24,7 @@ class CAS220102Section(ReportSection):
         }
 
         # Add reactor-specific volume replacements
-        if reactor_type == ReactorType.IFE:
+        if fusion_machine_type == FusionMachineType.IFE:
             self.replacements.update(
                 {
                     "VOL10": str(
@@ -35,7 +35,7 @@ class CAS220102Section(ReportSection):
                     ),  # For IFE, use V_HTS for VOL14
                 }
             )
-        elif reactor_type == ReactorType.MFE:
+        elif fusion_machine_type == FusionMachineType.MFE:
             self.replacements.update(
                 {
                     "VOL11": str(

--- a/pyfecons/report/sections/cas220103_section.py
+++ b/pyfecons/report/sections/cas220103_section.py
@@ -4,7 +4,7 @@ from typing import Union
 from pyfecons.costing.categories.cas220103_coils import CAS220103Coils
 from pyfecons.costing.categories.cas220103_lasers import CAS220103Lasers
 from pyfecons.costing.ife.cas22.nif_costs import get_nif_scaled_costs
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.inputs.lasers import Lasers
 from pyfecons.inputs.power_input import PowerInput
 from pyfecons.report.section import ReportSection
@@ -16,23 +16,23 @@ class CAS220103Section(ReportSection):
     def __init__(
         self,
         cas220103: Union[CAS220103Coils, CAS220103Lasers],
-        reactor_type: ReactorType,
+        fusion_machine_type: FusionMachineType,
         power_input: PowerInput = None,
         lasers: Lasers = None,
         coils=None,
     ):
         super().__init__()
 
-        if reactor_type == ReactorType.MFE:
+        if fusion_machine_type == FusionMachineType.MFE:
             if coils is None:
                 raise ValueError(
                     "coils parameter must be provided for MFE reactor type"
                 )
             self._init_mfe_coils(cas220103, coils)
-        elif reactor_type == ReactorType.IFE:
+        elif fusion_machine_type == FusionMachineType.IFE:
             self._init_ife_lasers(cas220103, power_input, lasers)
         else:
-            raise ValueError(f"Unsupported reactor type: {reactor_type}")
+            raise ValueError(f"Unsupported reactor type: {fusion_machine_type}")
 
     def _init_mfe_coils(self, cas220103: CAS220103Coils, coils):
         """Initialize for MFE coils case."""

--- a/pyfecons/report/sections/cas220104_section.py
+++ b/pyfecons/report/sections/cas220104_section.py
@@ -10,7 +10,7 @@ from pyfecons.costing.categories.cas220104_supplementary_heating import (
     CAS220104SupplementaryHeating,
 )
 from pyfecons.costing.ife.cas22.nif_costs import NifCost
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.helpers import safe_round
 from pyfecons.inputs.supplementary_heating import SupplementaryHeating
 from pyfecons.report.section import ReportSection
@@ -21,19 +21,19 @@ class CAS220104Section(ReportSection):
     def __init__(
         self,
         cas220104: Union[CAS220104SupplementaryHeating, CAS220104IgnitionLasers],
-        reactor_type: ReactorType,
+        fusion_machine_type: FusionMachineType,
         heating: SupplementaryHeating = None,
         cas220103: Union[CAS220103Coils, CAS220103Lasers] = None,
     ):
         super().__init__()
 
         self.cas220104 = cas220104
-        if reactor_type == ReactorType.MFE:
+        if fusion_machine_type == FusionMachineType.MFE:
             self._init_mfe_supplementary_heating(cas220104, heating)
-        elif reactor_type == ReactorType.IFE:
+        elif fusion_machine_type == FusionMachineType.IFE:
             self._init_ife_ignition_lasers(cas220104, cas220103)
         else:
-            raise ValueError(f"Unsupported reactor type: {reactor_type}")
+            raise ValueError(f"Unsupported reactor type: {fusion_machine_type}")
 
     def _init_mfe_supplementary_heating(
         self, cas220104: CAS220104SupplementaryHeating, heating: SupplementaryHeating

--- a/pyfecons/report/sections/cas220106_section.py
+++ b/pyfecons/report/sections/cas220106_section.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 from pyfecons.costing.calculations.conversions import to_m_usd
 from pyfecons.costing.categories.cas220106 import CAS220106
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.inputs.vacuum_system import VacuumSystem
 from pyfecons.report.section import ReportSection
 
@@ -12,18 +12,18 @@ class CAS220106Section(ReportSection):
     def __init__(
         self,
         cas220106: CAS220106,
-        reactor_type: ReactorType,
+        fusion_machine_type: FusionMachineType,
         vacuum_system: VacuumSystem,
     ):
         super().__init__()
 
         self.cas220106 = cas220106
-        if reactor_type == ReactorType.MFE:
+        if fusion_machine_type == FusionMachineType.MFE:
             self._init_mfe(cas220106)
-        elif reactor_type == ReactorType.IFE:
+        elif fusion_machine_type == FusionMachineType.IFE:
             self._init_ife(cas220106, vacuum_system)
         else:
-            raise ValueError(f"Unsupported reactor type: {reactor_type}")
+            raise ValueError(f"Unsupported reactor type: {fusion_machine_type}")
 
     def _init_mfe(self, cas220106: CAS220106):
         self.template_file = "CAS220106_MFE.tex"

--- a/pyfecons/report/sections/cas220107_section.py
+++ b/pyfecons/report/sections/cas220107_section.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from pyfecons.costing.categories.cas220107 import CAS220107
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.figures.cap_derate import CapDerateFigure
 from pyfecons.inputs.basic import Basic
 from pyfecons.inputs.power_supplies import PowerSupplies
@@ -17,12 +17,12 @@ class CAS220107Section(ReportSection):
         power_supplies: PowerSupplies,
     ):
         super().__init__()
-        if basic.reactor_type == ReactorType.MFE:
+        if basic.fusion_machine_type == FusionMachineType.MFE:
             self._init_mfe(cas220107, basic)
-        elif basic.reactor_type == ReactorType.IFE:
+        elif basic.fusion_machine_type == FusionMachineType.IFE:
             self._init_ife(cas220107, basic, power_supplies)
         else:
-            raise ValueError(f"Unsupported reactor type: {basic.reactor_type}")
+            raise ValueError(f"Unsupported reactor type: {basic.fusion_machine_type}")
 
     def _init_mfe(self, cas220107: CAS220107, basic: Basic):
         self.template_file = "CAS220107_MFE.tex"

--- a/pyfecons/report/sections/cas220108_section.py
+++ b/pyfecons/report/sections/cas220108_section.py
@@ -3,7 +3,7 @@ from typing import Union
 
 from pyfecons.costing.categories.cas220108_divertor import CAS220108Divertor
 from pyfecons.costing.categories.cas220108_target_factory import CAS220108TargetFactory
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.figures import TargetPfrFigure
 from pyfecons.report.section import ReportSection
 
@@ -13,15 +13,15 @@ class CAS220108Section(ReportSection):
     def __init__(
         self,
         cas220108: Union[CAS220108Divertor, CAS220108TargetFactory],
-        reactor_type: ReactorType,
+        fusion_machine_type: FusionMachineType,
     ):
         super().__init__()
-        if reactor_type == ReactorType.MFE:
+        if fusion_machine_type == FusionMachineType.MFE:
             self._init_mfe(cas220108)
-        elif reactor_type == ReactorType.IFE:
+        elif fusion_machine_type == FusionMachineType.IFE:
             self._init_ife(cas220108)
         else:
-            raise ValueError(f"Unsupported reactor type: {reactor_type}")
+            raise ValueError(f"Unsupported reactor type: {fusion_machine_type}")
 
     def _init_mfe(self, cas220108: CAS220108Divertor):
         self.template_file = "CAS220108_MFE.tex"

--- a/pyfecons/report/sections/cas800000_section.py
+++ b/pyfecons/report/sections/cas800000_section.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from pyfecons.costing.categories.cas800000 import CAS80
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.inputs.blanket import Blanket
 from pyfecons.report.section import ReportSection
 
@@ -11,16 +11,16 @@ class CAS80Section(ReportSection):
     def __init__(
         self,
         cas80: CAS80,
-        reactor_type: ReactorType,
+        fusion_machine_type: FusionMachineType,
         blanket: Blanket,
     ):
         super().__init__()
-        if reactor_type == ReactorType.MFE:
+        if fusion_machine_type == FusionMachineType.MFE:
             self._init_mfe(cas80, blanket)
-        elif reactor_type == ReactorType.IFE:
+        elif fusion_machine_type == FusionMachineType.IFE:
             self._init_ife(cas80)
         else:
-            raise ValueError(f"Unsupported reactor type: {reactor_type}")
+            raise ValueError(f"Unsupported reactor type: {fusion_machine_type}")
 
     def _init_mfe(self, cas80: CAS80, blanket: Blanket):
         self.template_file = "CAS800000_DT.tex"

--- a/pyfecons/report/sections/cost_table_section.py
+++ b/pyfecons/report/sections/cost_table_section.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from pyfecons.costing_data import CostingData
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.report.cost_table.cost_table_ife import (
     get_replacements as get_ife_replacements,
 )
@@ -16,13 +16,13 @@ class CostTableSection(ReportSection):
     def __init__(
         self,
         costing_data: CostingData,
-        reactor_type: ReactorType,
+        fusion_machine_type: FusionMachineType,
     ):
         super().__init__()
         self.template_file = "CASstructure.tex"
-        if reactor_type == ReactorType.MFE:
+        if fusion_machine_type == FusionMachineType.MFE:
             self.replacements = get_mfe_replacements(costing_data)
-        elif reactor_type == ReactorType.IFE:
+        elif fusion_machine_type == FusionMachineType.IFE:
             self.replacements = get_ife_replacements(costing_data)
         else:
-            raise ValueError(f"Unsupported reactor type: {reactor_type}")
+            raise ValueError(f"Unsupported reactor type: {fusion_machine_type}")

--- a/pyfecons/report/sections/power_table_section.py
+++ b/pyfecons/report/sections/power_table_section.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Any, Dict
 
 from pyfecons.costing.accounting.power_table import PowerTable
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.inputs.basic import Basic
 from pyfecons.inputs.power_input import PowerInput
 from pyfecons.report.section import ReportSection
@@ -15,7 +15,7 @@ class PowerTableSection(ReportSection):
     def __init__(self, power_table: PowerTable, basic: Basic, power_input: PowerInput):
         super().__init__()
 
-        if basic.reactor_type == ReactorType.MFE:  # MFE
+        if basic.fusion_machine_type == FusionMachineType.MFE:  # MFE
             self.template_file = "powerTableMFEDT.tex"
             self.replacements = {
                 # Ordered by occurrence in template
@@ -54,7 +54,7 @@ class PowerTableSection(ReportSection):
                 ),  # Recirculating power fraction
                 "PNET": power_table.p_net,  # Output Power (Net Electric Power)
             }
-        elif basic.reactor_type == ReactorType.IFE:
+        elif basic.fusion_machine_type == FusionMachineType.IFE:
             self.template_file = "powerTableIFEDT.tex"
             self.replacements = {
                 "PNRL": round(basic.p_nrl, 1),
@@ -88,4 +88,4 @@ class PowerTableSection(ReportSection):
                 "PIN": round(power_input.p_input, 1),
             }
         else:
-            raise ValueError(f"Unknown reactor type: {basic.reactor_type}")
+            raise ValueError(f"Unknown reactor type: {basic.fusion_machine_type}")

--- a/pyfecons/report/utils.py
+++ b/pyfecons/report/utils.py
@@ -48,7 +48,7 @@ def get_report_sections(
     inputs: AllInputs, costing_data: CostingData
 ) -> List[ReportSection]:
     """Get all report sections with their templates and replacements."""
-    reactor_type = inputs.basic.reactor_type
+    fusion_machine_type = inputs.basic.fusion_machine_type
     return [
         PowerTableSection(costing_data.power_table, inputs.basic, inputs.power_input),
         CAS10Section(costing_data.cas10, inputs.basic),
@@ -56,26 +56,28 @@ def get_report_sections(
         CAS220101Section(
             costing_data.cas220101, inputs.basic, inputs.radial_build, inputs.blanket
         ),
-        CAS220102Section(costing_data.cas220102, reactor_type),
+        CAS220102Section(costing_data.cas220102, fusion_machine_type),
         CAS220103Section(
             costing_data.cas220103,
-            reactor_type,
+            fusion_machine_type,
             inputs.power_input,
             inputs.lasers,
             inputs.coils,
         ),
         CAS220104Section(
             costing_data.cas220104,
-            reactor_type,
+            fusion_machine_type,
             inputs.supplementary_heating,
             costing_data.cas220103,
         ),
         CAS220105Section(
             costing_data.cas220105, inputs.basic, inputs.primary_structure
         ),
-        CAS220106Section(costing_data.cas220106, reactor_type, inputs.vacuum_system),
+        CAS220106Section(
+            costing_data.cas220106, fusion_machine_type, inputs.vacuum_system
+        ),
         CAS220107Section(costing_data.cas220107, inputs.basic, inputs.power_supplies),
-        CAS220108Section(costing_data.cas220108, reactor_type),
+        CAS220108Section(costing_data.cas220108, fusion_machine_type),
         CAS220109Section(costing_data.cas220109),
         CAS220111Section(costing_data.cas220111, inputs.basic, inputs.installation),
         CAS220119Section(costing_data.cas220119),
@@ -99,7 +101,7 @@ def get_report_sections(
         CAS50Section(costing_data.cas50),
         CAS60Section(costing_data.cas60),
         CAS70Section(costing_data.cas70),
-        CAS80Section(costing_data.cas80, reactor_type, inputs.blanket),
+        CAS80Section(costing_data.cas80, fusion_machine_type, inputs.blanket),
         CAS90Section(costing_data.cas90),
         LcoeSection(
             costing_data.lcoe,
@@ -109,7 +111,7 @@ def get_report_sections(
             costing_data.cas80,
             costing_data.cas90,
         ),
-        CostTableSection(costing_data, reactor_type),
+        CostTableSection(costing_data, fusion_machine_type),
         NpvSection(costing_data.npv, inputs.npv_input),
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt", encoding="utf-8") as f:
 
 setup(
     name="pyfecons",
-    version="0.1.3",
+    version="0.1.4",
     author="Woodruff Scientific LTD",
     author_email="info@woodruffscientific.com",
     description="Library for PyFECONS costing calculations.",

--- a/tests/test_blanket_parameters.py
+++ b/tests/test_blanket_parameters.py
@@ -21,7 +21,7 @@ from pyfecons.enums import (
     BlanketSecondaryCoolant,
     BlanketStructure,
     BlanketType,
-    ReactorType,
+    FusionMachineType,
 )
 from pyfecons.inputs.all_inputs import AllInputs
 from pyfecons.inputs.blanket import Blanket
@@ -38,19 +38,19 @@ def load_mfe_inputs() -> AllInputs:
     return _load_inputs_from_customer_dir("mfe")
 
 
-def _load_inputs_from_customer_dir(reactor_type: str) -> AllInputs:
+def _load_inputs_from_customer_dir(fusion_machine_type: str) -> AllInputs:
     """
     Load inputs from a customer DefineInputs.py file.
 
     Args:
-        reactor_type: Either "ife" or "mfe"
+        fusion_machine_type: Either "ife" or "mfe"
 
     Returns:
         AllInputs object from the DefineInputs.Generate() function
     """
     # Add the customer directory to the path
     customer_dir = os.path.join(
-        os.path.dirname(__file__), "..", "customers", "CATF", reactor_type
+        os.path.dirname(__file__), "..", "customers", "CATF", fusion_machine_type
     )
     customer_dir = os.path.abspath(customer_dir)
     sys.path.insert(0, customer_dir)
@@ -146,7 +146,7 @@ class TestIFEBlanketParameters:
         costing_data = RunCosting(test_inputs)
 
         assert costing_data is not None
-        assert costing_data.reactor_type == ReactorType.IFE
+        assert costing_data.fusion_machine_type == FusionMachineType.IFE
         assert isinstance(costing_data.cas22.C220100, M_USD)
         assert costing_data.cas22.C220100 > M_USD(0)
 
@@ -173,7 +173,7 @@ class TestIFEBlanketParameters:
         costing_data = RunCosting(test_inputs)
 
         assert costing_data is not None
-        assert costing_data.reactor_type == ReactorType.IFE
+        assert costing_data.fusion_machine_type == FusionMachineType.IFE
         assert isinstance(costing_data.cas22.C220100, M_USD)
         assert costing_data.cas22.C220100 > M_USD(0)
 
@@ -200,7 +200,7 @@ class TestIFEBlanketParameters:
         costing_data = RunCosting(test_inputs)
 
         assert costing_data is not None
-        assert costing_data.reactor_type == ReactorType.IFE
+        assert costing_data.fusion_machine_type == FusionMachineType.IFE
         assert isinstance(costing_data.cas22.C220100, M_USD)
         assert costing_data.cas22.C220100 > M_USD(0)
 
@@ -227,7 +227,7 @@ class TestIFEBlanketParameters:
         costing_data = RunCosting(test_inputs)
 
         assert costing_data is not None
-        assert costing_data.reactor_type == ReactorType.IFE
+        assert costing_data.fusion_machine_type == FusionMachineType.IFE
         assert isinstance(costing_data.cas22.C220100, M_USD)
         assert costing_data.cas22.C220100 > M_USD(0)
 
@@ -254,7 +254,7 @@ class TestIFEBlanketParameters:
         costing_data = RunCosting(test_inputs)
 
         assert costing_data is not None
-        assert costing_data.reactor_type == ReactorType.IFE
+        assert costing_data.fusion_machine_type == FusionMachineType.IFE
         assert isinstance(costing_data.cas22.C220100, M_USD)
         assert costing_data.cas22.C220100 > M_USD(0)
 
@@ -281,7 +281,7 @@ class TestIFEBlanketParameters:
         costing_data = RunCosting(test_inputs)
 
         assert costing_data is not None
-        assert costing_data.reactor_type == ReactorType.IFE
+        assert costing_data.fusion_machine_type == FusionMachineType.IFE
         assert isinstance(costing_data.cas22.C220100, M_USD)
         assert costing_data.cas22.C220100 > M_USD(0)
 
@@ -324,7 +324,7 @@ class TestMFEBlanketParameters:
         costing_data = RunCosting(test_inputs)
 
         assert costing_data is not None
-        assert costing_data.reactor_type == ReactorType.MFE
+        assert costing_data.fusion_machine_type == FusionMachineType.MFE
         assert isinstance(costing_data.cas22.C220100, M_USD)
         assert costing_data.cas22.C220100 > M_USD(0)
 
@@ -351,7 +351,7 @@ class TestMFEBlanketParameters:
         costing_data = RunCosting(test_inputs)
 
         assert costing_data is not None
-        assert costing_data.reactor_type == ReactorType.MFE
+        assert costing_data.fusion_machine_type == FusionMachineType.MFE
         assert isinstance(costing_data.cas22.C220100, M_USD)
         assert costing_data.cas22.C220100 > M_USD(0)
 
@@ -378,7 +378,7 @@ class TestMFEBlanketParameters:
         costing_data = RunCosting(test_inputs)
 
         assert costing_data is not None
-        assert costing_data.reactor_type == ReactorType.MFE
+        assert costing_data.fusion_machine_type == FusionMachineType.MFE
         assert isinstance(costing_data.cas22.C220100, M_USD)
         assert costing_data.cas22.C220100 > M_USD(0)
 
@@ -405,7 +405,7 @@ class TestMFEBlanketParameters:
         costing_data = RunCosting(test_inputs)
 
         assert costing_data is not None
-        assert costing_data.reactor_type == ReactorType.MFE
+        assert costing_data.fusion_machine_type == FusionMachineType.MFE
         assert isinstance(costing_data.cas22.C220100, M_USD)
         assert costing_data.cas22.C220100 > M_USD(0)
 
@@ -432,7 +432,7 @@ class TestMFEBlanketParameters:
         costing_data = RunCosting(test_inputs)
 
         assert costing_data is not None
-        assert costing_data.reactor_type == ReactorType.MFE
+        assert costing_data.fusion_machine_type == FusionMachineType.MFE
         assert isinstance(costing_data.cas22.C220100, M_USD)
         assert costing_data.cas22.C220100 > M_USD(0)
 
@@ -459,7 +459,7 @@ class TestMFEBlanketParameters:
         costing_data = RunCosting(test_inputs)
 
         assert costing_data is not None
-        assert costing_data.reactor_type == ReactorType.MFE
+        assert costing_data.fusion_machine_type == FusionMachineType.MFE
         assert isinstance(costing_data.cas22.C220100, M_USD)
         assert costing_data.cas22.C220100 > M_USD(0)
 

--- a/tests/test_cas220101_cost_functions.py
+++ b/tests/test_cas220101_cost_functions.py
@@ -11,7 +11,7 @@ from pyfecons.enums import (
     BlanketStructure,
     BlanketType,
     ConfinementType,
-    ReactorType,
+    FusionMachineType,
 )
 from pyfecons.inputs.blanket import Blanket
 from pyfecons.inputs.radial_build import RadialBuild
@@ -45,7 +45,7 @@ def test_mfe_tokamak_cas220101_total_cost():
         bioshield_t=Meters(1),
     )
     result_cost = compute_cas22_reactor_equipment_total_cost(
-        reactor_type=ReactorType.MFE,
+        fusion_machine_type=FusionMachineType.MFE,
         confinement_type=ConfinementType.SPHERICAL_TOKAMAK,
         radial_build=radial_build,
         blanket=blanket,
@@ -83,7 +83,7 @@ def test_mfe_mirror_cas220101_total_cost():
         bioshield_t=Meters(1),
     )
     result_cost = compute_cas22_reactor_equipment_total_cost(
-        ReactorType.MFE, ConfinementType.MAGNETIC_MIRROR, blanket, radial_build
+        FusionMachineType.MFE, ConfinementType.MAGNETIC_MIRROR, blanket, radial_build
     )
     expected_result_cost = (
         1217.12  #! this could become deprecated if cost calculation changes
@@ -118,7 +118,7 @@ def test_mfe_mirror_minimal_cas220101_total_cost():
         bioshield_t=Meters(0),
     )
     result_cost = compute_cas22_reactor_equipment_total_cost(
-        ReactorType.MFE, ConfinementType.MAGNETIC_MIRROR, blanket, radial_build
+        FusionMachineType.MFE, ConfinementType.MAGNETIC_MIRROR, blanket, radial_build
     )
     expected_result_cost = (
         84.315  #! this could become deprecated if cost calculation changes

--- a/tests/test_ife.py
+++ b/tests/test_ife.py
@@ -11,7 +11,7 @@ import sys
 import pytest
 
 from pyfecons import RunCosting
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.units import M_USD
 
 
@@ -50,7 +50,7 @@ def test_ife_direct_drive_full_costing():
 
     # Validate that costing_data was created successfully
     assert costing_data is not None
-    assert costing_data.reactor_type == ReactorType.IFE
+    assert costing_data.fusion_machine_type == FusionMachineType.IFE
 
     # Check that major cost categories were calculated
     assert hasattr(costing_data, "cas10")  # Pre-construction costs
@@ -89,7 +89,7 @@ def test_ife_indirect_drive_full_costing():
 
     # Validate that costing_data was created successfully
     assert costing_data is not None
-    assert costing_data.reactor_type == ReactorType.IFE
+    assert costing_data.fusion_machine_type == FusionMachineType.IFE
 
     # Check that major cost categories were calculated
     assert hasattr(costing_data, "cas10")
@@ -212,7 +212,7 @@ def test_ife_vs_mfe_differences():
     assert ife_data.cas22.C220000 > M_USD(0)
 
     # IFE reactor type should be correct
-    assert ife_data.reactor_type == ReactorType.IFE
+    assert ife_data.fusion_machine_type == FusionMachineType.IFE
 
     print("IFE vs MFE cost structure differences validated")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,7 +13,7 @@ import sys
 import pytest
 
 from pyfecons import RunCosting
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.units import M_USD
 
 sys.path.append(os.path.dirname(__file__))
@@ -31,7 +31,7 @@ def test_mfe_tokamak_integration():
 
     # Basic validation
     assert costing_data is not None
-    assert costing_data.reactor_type == ReactorType.MFE
+    assert costing_data.fusion_machine_type == FusionMachineType.MFE
 
     # Check that all major cost categories exist and are positive
     assert hasattr(costing_data, "cas10") and costing_data.cas10.C100000 > 0
@@ -58,7 +58,7 @@ def test_mfe_mirror_integration():
 
     # Basic validation
     assert costing_data is not None
-    assert costing_data.reactor_type == ReactorType.MFE
+    assert costing_data.fusion_machine_type == FusionMachineType.MFE
 
     # Check that all major cost categories exist and are positive
     assert hasattr(costing_data, "cas10") and costing_data.cas10.C100000 > 0
@@ -82,7 +82,7 @@ def test_ife_integration():
 
     # Basic validation
     assert costing_data is not None
-    assert costing_data.reactor_type == ReactorType.IFE
+    assert costing_data.fusion_machine_type == FusionMachineType.IFE
 
     # Check that all major cost categories exist and are positive
     assert hasattr(costing_data, "cas10") and costing_data.cas10.C100000 > 0
@@ -111,7 +111,7 @@ def test_costing_data_structure():
 
     # Test that both have the same major structure
     expected_attributes = [
-        "reactor_type",
+        "fusion_machine_type",
         "power_table",
         "cas10",
         "cas21",
@@ -140,8 +140,8 @@ def test_costing_data_structure():
         assert hasattr(ife_data, attr), f"IFE missing {attr}"
 
     # Test that reactor types are correct
-    assert mfe_data.reactor_type == ReactorType.MFE
-    assert ife_data.reactor_type == ReactorType.IFE
+    assert mfe_data.fusion_machine_type == FusionMachineType.MFE
+    assert ife_data.fusion_machine_type == FusionMachineType.IFE
 
     print("✓ Both MFE and IFE have consistent costing data structure")
 

--- a/tests/test_mfe.py
+++ b/tests/test_mfe.py
@@ -11,7 +11,7 @@ import sys
 import pytest
 
 from pyfecons import RunCosting
-from pyfecons.enums import ReactorType
+from pyfecons.enums import FusionMachineType
 from pyfecons.units import M_USD
 
 
@@ -50,7 +50,7 @@ def test_mfe_tokamak_full_costing():
 
     # Validate that costing_data was created successfully
     assert costing_data is not None
-    assert costing_data.reactor_type == ReactorType.MFE
+    assert costing_data.fusion_machine_type == FusionMachineType.MFE
 
     # Check that major cost categories were calculated
     assert hasattr(costing_data, "cas10")  # Pre-construction costs
@@ -83,7 +83,7 @@ def test_mfe_mirror_full_costing():
 
     # Validate that costing_data was created successfully
     assert costing_data is not None
-    assert costing_data.reactor_type == ReactorType.MFE
+    assert costing_data.fusion_machine_type == FusionMachineType.MFE
 
     # Check that major cost categories were calculated
     assert hasattr(costing_data, "cas10")


### PR DESCRIPTION
As discussed, in order to shy away from fission, the nomenclature "Reactor Type" will be "Fusion Machine Type".